### PR TITLE
Add option to roll cluster on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,25 @@ Available targets:
 | aws | >= 3.18 |
 | spotinst | >= 1.30 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| this | cloudposse/label/null | 0.24.1 |
+| worker_label | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) |
+| [aws_iam_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
+| [aws_partition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) |
+| [spotinst_ocean_aws](https://registry.terraform.io/providers/spotinst/spotinst/latest/docs/resources/ocean_aws) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -208,6 +227,8 @@ Available targets:
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | subnet\_ids | A list of subnet IDs to launch resources in | `list(string)` | n/a | yes |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| update\_policy\_batch\_size\_percentage | When rolling the cluster due to an update, the percentage of the instances to deploy in each batch. | `number` | `25` | no |
+| update\_policy\_should\_roll | If true, roll the cluster when its configuration is updated | `bool` | `true` | no |
 | userdata\_override\_base64 | Many features of this module rely on the `bootstrap.sh` provided with Amazon Linux, and this module<br>may generate "user data" that expects to find that script. If you want to use an AMI that is not<br>compatible with the Amazon Linux `bootstrap.sh` initialization, then use `userdata_override_base64` to provide<br>your own (Base64 encoded) user data. Use "" to prevent any user data from being set.<br><br>Setting `userdata_override_base64` disables `kubernetes_taints`, `kubelet_additional_options`,<br>`before_cluster_joining_userdata`, `after_cluster_joining_userdata`, and `bootstrap_additional_options`. | `string` | `null` | no |
 
 ## Outputs
@@ -216,7 +237,6 @@ Available targets:
 |------|-------------|
 | ocean\_controller\_id | The ID of the Ocean controller |
 | worker\_role\_arn | The ARN of the role for worker instances, if created by this module (`var.instance_profile == null`) |
-
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -17,6 +17,25 @@
 | aws | >= 3.18 |
 | spotinst | >= 1.30 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| this | cloudposse/label/null | 0.24.1 |
+| worker_label | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) |
+| [aws_iam_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
+| [aws_partition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) |
+| [spotinst_ocean_aws](https://registry.terraform.io/providers/spotinst/spotinst/latest/docs/resources/ocean_aws) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -61,6 +80,8 @@
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | subnet\_ids | A list of subnet IDs to launch resources in | `list(string)` | n/a | yes |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| update\_policy\_batch\_size\_percentage | When rolling the cluster due to an update, the percentage of the instances to deploy in each batch. | `number` | `25` | no |
+| update\_policy\_should\_roll | If true, roll the cluster when its configuration is updated | `bool` | `true` | no |
 | userdata\_override\_base64 | Many features of this module rely on the `bootstrap.sh` provided with Amazon Linux, and this module<br>may generate "user data" that expects to find that script. If you want to use an AMI that is not<br>compatible with the Amazon Linux `bootstrap.sh` initialization, then use `userdata_override_base64` to provide<br>your own (Base64 encoded) user data. Use "" to prevent any user data from being set.<br><br>Setting `userdata_override_base64` disables `kubernetes_taints`, `kubelet_additional_options`,<br>`before_cluster_joining_userdata`, `after_cluster_joining_userdata`, and `bootstrap_additional_options`. | `string` | `null` | no |
 
 ## Outputs
@@ -69,5 +90,4 @@
 |------|-------------|
 | ocean\_controller\_id | The ID of the Ocean controller |
 | worker\_role\_arn | The ARN of the role for worker instances, if created by this module (`var.instance_profile == null`) |
-
 <!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,14 @@ resource "spotinst_ocean_aws" "this" {
     autoscale_is_auto_config = true
   }
 
+  update_policy {
+    should_roll = var.update_policy_should_roll
+
+    roll_config {
+      batch_size_percentage = var.update_policy_batch_size_percentage
+    }
+  }
+
   lifecycle {
     ignore_changes = [desired_capacity]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -201,13 +201,13 @@ variable "userdata_override_base64" {
 }
 
 variable "update_policy_should_roll" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "If true, roll the cluster when its configuration is updated"
 }
 
 variable "update_policy_batch_size_percentage" {
-  type = number
-  default = 25
+  type        = number
+  default     = 25
   description = "When rolling the cluster due to an update, the percentage of the instances to deploy in each batch."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -199,3 +199,15 @@ variable "userdata_override_base64" {
     `before_cluster_joining_userdata`, `after_cluster_joining_userdata`, and `bootstrap_additional_options`.
     EOT
 }
+
+variable "update_policy_should_roll" {
+  type = bool
+  default = true
+  description = "If true, roll the cluster when its configuration is updated"
+}
+
+variable "update_policy_batch_size_percentage" {
+  type = number
+  default = 25
+  description = "When rolling the cluster due to an update, the percentage of the instances to deploy in each batch."
+}


### PR DESCRIPTION
## what
- Add option to roll cluster on update

## why
- By default, changes made via Terraform do not take effect until some other action causes the causes the instances to be replaced, which can take weeks

