### PR TITLE
Allow using `kubernetes` provider V1

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -56,3 +56,10 @@ pull_request_rules:
       changes_requested: true
       approved: true
       message: "This Pull Request has been updated, so we're dismissing all reviews."
+
+- name: "close Pull Requests without files changed"
+  conditions:
+    - "#files=0"
+  actions:
+    close:
+      message: "This pull request has been automatically closed by Mergify because there are no longer any changes."

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   auto-format:
     runs-on: ubuntu-latest
-    container: cloudposse/build-harness:slim-latest
+    container: cloudposse/build-harness:latest
     steps:
     # Checkout the pull request branch
     #  "An action in a workflow run can’t trigger a new workflow run. For example, if an action pushes code using
@@ -29,6 +29,8 @@ jobs:
     - name: Auto Format
       if: github.event.pull_request.state == 'open'
       shell: bash
+      env:
+        GITHUB_TOKEN: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
       run: make BUILD_HARNESS_PATH=/build-harness PACKAGES_PREFER_HOST=true -f /build-harness/templates/Makefile.build-harness pr/auto-format/host
 
     # Commit changes (if any) to the PR branch

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,17 +3,23 @@ name: auto-release
 on:
   push:
     branches:
-    - master
+      - master
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    # Drafts your next Release notes as Pull Requests are merged into "master"
-    - uses: release-drafter/release-drafter@v5
-      with:
-        publish: true
-        prerelease: false
-        config-name: auto-release.yml
-      env:
-        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+      # Get PR from merged commit to master
+      - uses: actions-ecosystem/action-get-merged-pull-request@v1
+        id: get-merged-pull-request
+        with:
+          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        if: "!contains(steps.get-merged-pull-request.outputs.labels, 'no-release')"
+        with:
+          publish: true
+          prerelease: false
+          config-name: auto-release.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Cloud Posse, LLC
+   Copyright 2020-2021 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Available targets:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.18 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 1.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
 | <a name="requirement_spotinst"></a> [spotinst](#requirement\_spotinst) | >= 1.30 |

--- a/ami.tf
+++ b/ami.tf
@@ -1,4 +1,3 @@
-
 locals {
   need_ami_id = var.ami_image_id == null
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,7 +5,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.18 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 1.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
 | <a name="requirement_spotinst"></a> [spotinst](#requirement\_spotinst) | >= 1.30 |

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -6,7 +6,7 @@ environment = "ue2"
 
 stage = "test"
 
-name = "example"
+name = "spotinst"
 
 availability_zones = ["us-east-2a", "us-east-2b", "us-east-2c"]
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -34,7 +34,7 @@ module "vpc" {
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "0.37.6"
+  version = "0.38.0"
 
   tags = local.vpc_tags
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,6 +1,3 @@
-
-
-
 module "eks_cluster_label" {
   source  = "cloudposse/label/null"
   version = "0.24.1"
@@ -23,21 +20,17 @@ locals {
   private_subnets_additional_tags = {
     "kubernetes.io/role/internal-elb" : 1
   }
-
 }
-
 
 module "vpc" {
   source  = "cloudposse/vpc/aws"
-  version = "0.20.4"
+  version = "0.21.1"
 
   cidr_block = "172.16.0.0/16"
   tags       = local.vpc_tags
 
   context = module.this.context
 }
-
-
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
@@ -57,12 +50,9 @@ module "subnets" {
   context = module.this.context
 }
 
-
-
-
 module "eks_cluster" {
   source  = "cloudposse/eks-cluster/aws"
-  version = "0.34.0"
+  version = "0.38.0"
 
   region                = var.region
   vpc_id                = module.vpc.vpc_id

--- a/instance-profile.tf
+++ b/instance-profile.tf
@@ -36,6 +36,7 @@ resource "aws_iam_instance_profile" "worker" {
   name  = module.worker_label.id
   role  = join("", aws_iam_role.worker.*.name)
 }
+
 resource "aws_iam_role" "worker" {
   count              = local.instance_profile_enabled ? 1 : 0
   name               = module.worker_label.id

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,3 @@
-
 locals {
   enabled            = module.this.enabled
   cluster_name       = var.eks_cluster_id

--- a/userdata.tf
+++ b/userdata.tf
@@ -18,9 +18,11 @@
 locals {
   kubelet_label_settings = [for k, v in var.kubernetes_labels : format("%v=%v", k, v)]
   kubelet_taint_settings = [for k, v in var.kubernetes_taints : format("%v=%v", k, v)]
+
   kubelet_label_args = (length(local.kubelet_label_settings) == 0 ? "" :
     "--node-labels=${join(",", local.kubelet_label_settings)}"
   )
+
   kubelet_taint_args = (length(local.kubelet_taint_settings) == 0 ? "" :
     "--register-with-taints=${join(",", local.kubelet_taint_settings)}"
   )

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,3 @@
-
 variable "region" {
   type        = string
   description = "AWS Region"

--- a/versions.tf
+++ b/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.0"
+      version = ">= 1.0"
     }
     spotinst = {
       source  = "spotinst/spotinst"


### PR DESCRIPTION
## what
* Allow using `kubernetes` provider V1
* Bump module versions
* Update GitHub actions

## why
* `kubernetes` provider V2 has issues with race conditions when creating/updating/deleting EKS clusters
* Allow top-level modules to decide on which version of the `kubernetes` provider to use 
* Keep up to date

