### PR TITLE
Adds variable `fallback_to_ondemand`

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Available targets:
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_existing_workers_role_policy_arns"></a> [existing\_workers\_role\_policy\_arns](#input\_existing\_workers\_role\_policy\_arns) | List of existing policy ARNs that will be attached to the workers default role on creation | `list(string)` | `[]` | no |
+| <a name="input_fallback_to_ondemand"></a> [fallback\_to\_ondemand](#input\_fallback\_to\_ondemand) | If not Spot instance markets are available, enable Ocean to launch On-Demand instances instead. | `bool` | `true` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_instance_profile"></a> [instance\_profile](#input\_instance\_profile) | The AWS Instance Profile to use for Spotinst Worker instances. If not set, one will be created. | `string` | `null` | no |
 | <a name="input_instance_types"></a> [instance\_types](#input\_instance\_types) | List of instance type to use for this node group. Defaults to null, which allows all instance types. | `list(string)` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Available targets:
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_existing_workers_role_policy_arns"></a> [existing\_workers\_role\_policy\_arns](#input\_existing\_workers\_role\_policy\_arns) | List of existing policy ARNs that will be attached to the workers default role on creation | `list(string)` | `[]` | no |
-| <a name="input_fallback_to_ondemand"></a> [fallback\_to\_ondemand](#input\_fallback\_to\_ondemand) | If not Spot instance markets are available, enable Ocean to launch On-Demand instances instead. | `bool` | `true` | no |
+| <a name="input_fallback_to_ondemand"></a> [fallback\_to\_ondemand](#input\_fallback\_to\_ondemand) | If no Spot instance markets are available, enable Ocean to launch On-Demand instances instead. | `bool` | `true` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_instance_profile"></a> [instance\_profile](#input\_instance\_profile) | The AWS Instance Profile to use for Spotinst Worker instances. If not set, one will be created. | `string` | `null` | no |
 | <a name="input_instance_types"></a> [instance\_types](#input\_instance\_types) | List of instance type to use for this node group. Defaults to null, which allows all instance types. | `list(string)` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -61,6 +61,7 @@
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_existing_workers_role_policy_arns"></a> [existing\_workers\_role\_policy\_arns](#input\_existing\_workers\_role\_policy\_arns) | List of existing policy ARNs that will be attached to the workers default role on creation | `list(string)` | `[]` | no |
+| <a name="input_fallback_to_ondemand"></a> [fallback\_to\_ondemand](#input\_fallback\_to\_ondemand) | If not Spot instance markets are available, enable Ocean to launch On-Demand instances instead. | `bool` | `true` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_instance_profile"></a> [instance\_profile](#input\_instance\_profile) | The AWS Instance Profile to use for Spotinst Worker instances. If not set, one will be created. | `string` | `null` | no |
 | <a name="input_instance_types"></a> [instance\_types](#input\_instance\_types) | List of instance type to use for this node group. Defaults to null, which allows all instance types. | `list(string)` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -61,7 +61,7 @@
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_existing_workers_role_policy_arns"></a> [existing\_workers\_role\_policy\_arns](#input\_existing\_workers\_role\_policy\_arns) | List of existing policy ARNs that will be attached to the workers default role on creation | `list(string)` | `[]` | no |
-| <a name="input_fallback_to_ondemand"></a> [fallback\_to\_ondemand](#input\_fallback\_to\_ondemand) | If not Spot instance markets are available, enable Ocean to launch On-Demand instances instead. | `bool` | `true` | no |
+| <a name="input_fallback_to_ondemand"></a> [fallback\_to\_ondemand](#input\_fallback\_to\_ondemand) | If no Spot instance markets are available, enable Ocean to launch On-Demand instances instead. | `bool` | `true` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_instance_profile"></a> [instance\_profile](#input\_instance\_profile) | The AWS Instance Profile to use for Spotinst Worker instances. If not set, one will be created. | `string` | `null` | no |
 | <a name="input_instance_types"></a> [instance\_types](#input\_instance\_types) | List of instance type to use for this node group. Defaults to null, which allows all instance types. | `list(string)` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,7 @@ resource "spotinst_ocean_aws" "this" {
   iam_instance_profile        = var.instance_profile == null ? join("", aws_iam_instance_profile.worker.*.name) : var.instance_profile
   associate_public_ip_address = var.associate_public_ip_address
   user_data                   = local.userdata
+  fallback_to_ondemand        = var.fallback_to_ondemand
 
   dynamic "tags" {
     for_each = merge(local.default_tags, module.this.tags)

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,12 @@ variable "ec2_ssh_key" {
   default     = null
 }
 
+variable "fallback_to_ondemand" {
+  type        = bool
+  description = "If not Spot instance markets are available, enable Ocean to launch On-Demand instances instead."
+  default     = true
+}
+
 variable "subnet_ids" {
   description = "A list of subnet IDs to launch resources in"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -87,7 +87,7 @@ variable "ec2_ssh_key" {
 
 variable "fallback_to_ondemand" {
   type        = bool
-  description = "If not Spot instance markets are available, enable Ocean to launch On-Demand instances instead."
+  description = "If no Spot instance markets are available, enable Ocean to launch On-Demand instances instead."
   default     = true
 }
 


### PR DESCRIPTION
## what

* Provides control over whether or not the cluster should use `ondemand` instances if no `spot` instances are available.

## why

* Cost savings

## references

* [fallback_to_ondemand](https://registry.terraform.io/providers/spotinst/spotinst/latest/docs/resources/ocean_aws#fallback_to_ondemand)