### PR TITLE
Fix support of enabled flag, update provider requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,14 +154,14 @@ Available targets:
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 1.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
-| <a name="requirement_spotinst"></a> [spotinst](#requirement\_spotinst) | >= 1.30 |
+| <a name="requirement_spotinst"></a> [spotinst](#requirement\_spotinst) | >= 1.56 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.18 |
-| <a name="provider_spotinst"></a> [spotinst](#provider\_spotinst) | >= 1.30 |
+| <a name="provider_spotinst"></a> [spotinst](#provider\_spotinst) | >= 1.56 |
 
 ## Modules
 

--- a/ami.tf
+++ b/ami.tf
@@ -1,5 +1,5 @@
 locals {
-  need_ami_id = var.ami_image_id == null
+  need_ami_id = local.enabled && var.ami_image_id == null
 
   // "amazon-eks-gpu-node-",
   arch_label_map = {
@@ -34,7 +34,7 @@ locals {
 }
 
 data "aws_ami" "selected" {
-  count = local.enabled && local.need_ami_id ? 1 : 0
+  count = local.need_ami_id ? 1 : 0
 
   most_recent = true
   name_regex  = local.ami_regex

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -8,14 +8,14 @@
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 1.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
-| <a name="requirement_spotinst"></a> [spotinst](#requirement\_spotinst) | >= 1.30 |
+| <a name="requirement_spotinst"></a> [spotinst](#requirement\_spotinst) | >= 1.56 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.18 |
-| <a name="provider_spotinst"></a> [spotinst](#provider\_spotinst) | >= 1.30 |
+| <a name="provider_spotinst"></a> [spotinst](#provider\_spotinst) | >= 1.56 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
     }
     spotinst = {
       source  = "spotinst/spotinst"
-      version = ">= 1.30"
+      version = ">= 1.56"
     }
   }
 }


### PR DESCRIPTION
## what
- Fix support of `enabled` flag
- Update `spotinst` provider requirement to 1.56

## why
- All Cloud Posse modules should work and not create resources when `enabled = false` and required variables are provided. This module failed.
- PR #10 requires `spotinst` provider >= 1.56; earlier versions do not support the `instance_metadata_options` block.

