### PR TITLE
Add several outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,12 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | <a name="output_ocean_controller_id"></a> [ocean\_controller\_id](#output\_ocean\_controller\_id) | The ID of the Ocean controller |
+| <a name="output_ocean_id"></a> [ocean\_id](#output\_ocean\_id) | The ID of the Ocean (o-123b567c), if created by this module (`local.enabled`) |
+| <a name="output_worker_ami"></a> [worker\_ami](#output\_worker\_ami) | The AMI ID that the worker instance uses, if determined by this module (`var.ami_image_id == null`) |
+| <a name="output_worker_instance_profile_arn"></a> [worker\_instance\_profile\_arn](#output\_worker\_instance\_profile\_arn) | The ARN of the profile for worker instances, if created by this module (`var.instance_profile == null`) |
+| <a name="output_worker_instance_profile_name"></a> [worker\_instance\_profile\_name](#output\_worker\_instance\_profile\_name) | The name of the profile for worker instances, if created by this module (`var.instance_profile == null`) |
 | <a name="output_worker_role_arn"></a> [worker\_role\_arn](#output\_worker\_role\_arn) | The ARN of the role for worker instances, if created by this module (`var.instance_profile == null`) |
+| <a name="output_worker_role_name"></a> [worker\_role\_name](#output\_worker\_role\_name) | The name of the role for worker instances, if created by this module (`var.instance_profile == null`) |
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -98,5 +98,10 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_ocean_controller_id"></a> [ocean\_controller\_id](#output\_ocean\_controller\_id) | The ID of the Ocean controller |
+| <a name="output_ocean_id"></a> [ocean\_id](#output\_ocean\_id) | The ID of the Ocean (o-123b567c), if created by this module (`local.enabled`) |
+| <a name="output_worker_ami"></a> [worker\_ami](#output\_worker\_ami) | The AMI ID that the worker instance uses, if determined by this module (`var.ami_image_id == null`) |
+| <a name="output_worker_instance_profile_arn"></a> [worker\_instance\_profile\_arn](#output\_worker\_instance\_profile\_arn) | The ARN of the profile for worker instances, if created by this module (`var.instance_profile == null`) |
+| <a name="output_worker_instance_profile_name"></a> [worker\_instance\_profile\_name](#output\_worker\_instance\_profile\_name) | The name of the profile for worker instances, if created by this module (`var.instance_profile == null`) |
 | <a name="output_worker_role_arn"></a> [worker\_role\_arn](#output\_worker\_role\_arn) | The ARN of the role for worker instances, if created by this module (`var.instance_profile == null`) |
+| <a name="output_worker_role_name"></a> [worker\_role\_name](#output\_worker\_role\_name) | The name of the role for worker instances, if created by this module (`var.instance_profile == null`) |
 <!-- markdownlint-restore -->

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -6,7 +6,7 @@ environment = "ue2"
 
 stage = "test"
 
-name = "spotinst"
+name = "example"
 
 availability_zones = ["us-east-2a", "us-east-2b", "us-east-2c"]
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -10,7 +10,7 @@ name = "spotinst"
 
 availability_zones = ["us-east-2a", "us-east-2b", "us-east-2c"]
 
-kubernetes_version = "1.18"
+kubernetes_version = "1.20"
 
 spotinst_workers_role_arn = "arn:aws:iam::126450723953:role/cpco-testing-spotinst-worker"
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,8 +1,8 @@
 module "eks_cluster_label" {
   source  = "cloudposse/label/null"
-  version = "0.24.1"
+  version = "0.25.0"
 
-  attributes = compact(concat(module.this.attributes, ["cluster"]))
+  attributes = ["cluster"]
 
   context = module.this.context
 }
@@ -24,7 +24,7 @@ locals {
 
 module "vpc" {
   source  = "cloudposse/vpc/aws"
-  version = "0.21.1"
+  version = "0.28.1"
 
   cidr_block = "172.16.0.0/16"
   tags       = local.vpc_tags
@@ -34,7 +34,7 @@ module "vpc" {
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "0.38.0"
+  version = "0.39.8"
 
   tags = local.vpc_tags
 
@@ -52,7 +52,7 @@ module "subnets" {
 
 module "eks_cluster" {
   source  = "cloudposse/eks-cluster/aws"
-  version = "0.38.0"
+  version = "0.43.4"
 
   region                = var.region
   vpc_id                = module.vpc.vpc_id
@@ -60,12 +60,16 @@ module "eks_cluster" {
   kubernetes_version    = var.kubernetes_version
   oidc_provider_enabled = true
   workers_role_arns     = [var.spotinst_workers_role_arn]
+  
+  kube_exec_auth_enabled = true
 
   context = module.this.context
 }
 
 module "spotinst_oceans" {
   source = "../.."
+
+  depends_on = [module.eks_cluster.kubernetes_config_map_id]
 
   attributes       = ["spotinst"]
   disk_size        = 20

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -60,7 +60,7 @@ module "eks_cluster" {
   kubernetes_version    = var.kubernetes_version
   oidc_provider_enabled = true
   workers_role_arns     = [var.spotinst_workers_role_arn]
-  
+
   kube_exec_auth_enabled = true
 
   context = module.this.context

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,32 @@ output "ocean_controller_id" {
   value       = local.controller_id
 }
 
+output "ocean_id" {
+  description = "The ID of the Ocean (o-123b567c), if created by this module (`local.enabled`)"
+  value       = local.enabled ? join("", spotinst_ocean_aws.this.*.id) : null
+}
+
+output "worker_ami" {
+  description = "The AMI ID that the worker instance uses, if determined by this module (`var.ami_image_id == null`)"
+  value       = local.need_ami_id ? join("", data.aws_ami.selected.*.id) : null
+}
+
 output "worker_role_arn" {
   description = "The ARN of the role for worker instances, if created by this module (`var.instance_profile == null`)"
   value       = local.enabled && var.instance_profile == null ? join("", aws_iam_role.worker.*.arn) : null
+}
+
+output "worker_role_name" {
+  description = "The name of the role for worker instances, if created by this module (`var.instance_profile == null`)"
+  value       = local.enabled && var.instance_profile == null ? join("", aws_iam_role.worker.*.name) : null
+}
+
+output "worker_instance_profile_arn" {
+  description = "The ARN of the profile for worker instances, if created by this module (`var.instance_profile == null`)"
+  value       = local.enabled && var.instance_profile == null ? join("", aws_iam_instance_profile.worker.*.arn) : null
+}
+
+output "worker_instance_profile_name" {
+  description = "The name of the profile for worker instances, if created by this module (`var.instance_profile == null`)"
+  value       = local.enabled && var.instance_profile == null ? join("", aws_iam_instance_profile.worker.*.name) : null
 }

--- a/test/src/Makefile
+++ b/test/src/Makefile
@@ -15,9 +15,8 @@ init:
 .PHONY : test
 ## Run tests
 test: init
-	@echo Spotinst Ocean Test not implemented >&2; exit 1
-		#	go mod download
-		#	go test -v -timeout 60m -run TestExamplesComplete
+	go mod download
+	go test -v -timeout 60m -run TestExamplesComplete
 
 ## Run tests in docker container
 docker/test:


### PR DESCRIPTION
## what
* Added several outputs to make the created resources usable from outside the module

## why
* A user may want to be able to create launch specs based on the created ocean
* A user may want to be able to use the workers role/instance profile arn/name
* A user may want to be able to re-use the used ami for the ocean in another launchspec to keep instances amis in sync

## references
`terratest` testing implemented by changes here and in https://github.com/cloudposse/testing.cloudposse.co/pull/113. Closes #11 