### PR TITLE
adding spot percentage to controll on-demand count

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Available targets:
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of security groups that will be attached to the autoscaling group | `list(string)` | n/a | yes |
+| <a name="input_spot_percentage"></a> [spot\_percentage](#input\_spot\_percentage) | The percentage of Spot instances that would spin up from the desired\_capacity number. | `number` | `100` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs to launch resources in | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -85,6 +85,7 @@
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of security groups that will be attached to the autoscaling group | `list(string)` | n/a | yes |
+| <a name="input_spot_percentage"></a> [spot\_percentage](#input\_spot\_percentage) | The percentage of Spot instances that would spin up from the desired\_capacity number. | `number` | `100` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs to launch resources in | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,7 @@ resource "spotinst_ocean_aws" "this" {
   associate_public_ip_address = var.associate_public_ip_address
   user_data                   = local.userdata
   fallback_to_ondemand        = var.fallback_to_ondemand
+  spot_percentage             = var.spot_percentage
 
   dynamic "tags" {
     for_each = merge(local.default_tags, module.this.tags)

--- a/variables.tf
+++ b/variables.tf
@@ -79,6 +79,12 @@ variable "instance_types" {
     EOT
 }
 
+variable "spot_percentage" {
+  type = number
+  description = "The percentage of Spot instances that would spin up from the desired_capacity number."
+  default = 100
+}
+
 variable "ec2_ssh_key" {
   type        = string
   description = "SSH key pair name to use to access the worker nodes launced by Ocean"

--- a/variables.tf
+++ b/variables.tf
@@ -80,9 +80,9 @@ variable "instance_types" {
 }
 
 variable "spot_percentage" {
-  type = number
+  type        = number
   description = "The percentage of Spot instances that would spin up from the desired_capacity number."
-  default = 100
+  default     = 100
 }
 
 variable "ec2_ssh_key" {


### PR DESCRIPTION
## what
* adding the optional spot_percentage to the spoitinst controller

## why
* By adding the spot_precentage you can control how many on-demand instances will be created instead of all spoint instances

## references
* This is the documentation about the [spot_percetnage](https://registry.terraform.io/providers/spotinst/spotinst/latest/docs/resources/ocean_aws#spot_percentage) option

